### PR TITLE
Add deepstack python requirement

### DIFF
--- a/custom_components/tflite_server/manifest.json
+++ b/custom_components/tflite_server/manifest.json
@@ -4,7 +4,8 @@
         "documentation": "https://github.com/robmarkcole/HASS-tensorflow-lite-rest-server",
         "requirements": [
                 "pillow",
-                "requests"
+                "requests",
+                "deepstack-python==0.4"
         ],
         "dependencies": [],
         "codeowners": [


### PR DESCRIPTION
As discuss in https://github.com/robmarkcole/HASS-tensorflow-lite-rest-server/issues/4#issue-606421679
